### PR TITLE
chore(*): getporter org updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes # _(issue)_
 
 _If there is not an existing issue, please make sure we have context on why this change is needed. See our Contributing Guide for [examples of when an existing issue isn't necessary][1]._
 
-[1]: https://github.com/deislabs/porter/blob/main/CONTRIBUTING.md#when-to-open-a-pull-request
+[1]: https://porter.sh/src/CONTRIBUTING.md#when-to-open-a-pull-request
 
 # Notes for the reviewer
 _Put any questions or notes for the reviewer here._

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ For users on MacOS, the Porter project maintains a <a href="https://brew.sh/">Ho
 
 This project follows the same guidelines as the Porter project. 💖 We are actively seeking out new contributors.
 
-<p align="center">Start with our <a href="https://porter.sh/contribute/">New Contributors Guide</a>. Please make sure to read the <a href ="https://github.com/deislabs/porter/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a> and <a href="https://github.com/deislabs/porter/blob/main/CONTRIBUTING.md">Contributing Guidelines</a>.
+<p align="center">Start with our <a href="https://porter.sh/contribute/">New Contributors Guide</a>. Please make sure to read the <a href ="https://porter.sh/src/CODE_OF_CONDUCT.md">Code of Conduct</a> and <a href="https://porter.sh/src/CONTRIBUTING.md">Contributing Guidelines</a>.


### PR DESCRIPTION

# What does this change
* updates URLs to remove old (deislabs) org references

# What issue does it fix
Ref https://github.com/getporter/porter/issues/1249

# Notes for the reviewer
n/a
# Checklist
- [ ] Unit Tests
- [x] Documentation
  - [ ] Documentation Not Impacted